### PR TITLE
String::toUtf8 is not static

### DIFF
--- a/src/efsw/platform/win/FileSystemImpl.cpp
+++ b/src/efsw/platform/win/FileSystemImpl.cpp
@@ -36,7 +36,7 @@ std::string FileSystem::getCurrentWorkingDirectory()
 #ifdef EFSW_COMPILER_MSVC
 	#if defined( UNICODE ) AND !defined( EFSW_NO_WIDECHAR )
 	wchar_t dir[_MAX_PATH];
-	return ( 0 != GetCurrentDirectoryW( _MAX_PATH, dir ) ) ? String( dir )::toUtf8() : std::string();
+	return ( 0 != GetCurrentDirectoryW( _MAX_PATH, dir ) ) ? String( dir ).toUtf8() : std::string();
 	#else
 	char dir[_MAX_PATH];
 	return ( 0 != GetCurrentDirectory( _MAX_PATH, dir ) ) ? String( dir, std::locale() ).toUtf8() : std::string();


### PR DESCRIPTION
Fix error in windows build with unicode