### PR TITLE
Fix building dynamic library with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,9 @@ target_include_directories(efsw
 if (VERBOSE)
 	target_compile_definitions(efsw PRIVATE EFSW_VERBOSE)
 endif()
+if (BUILD_SHARED_LIBS)
+	target_compile_definitions(efsw PRIVATE EFSW_DYNAMIC EFSW_EXPORTS)
+endif()
 
 # platforms
 if (WIN32)


### PR DESCRIPTION
Since `EFSW_DYNAMIC` and `EFSW_EXPORTS` definitions were missing when building with `-DBUILD_SHARED_LIBS=ON`, the library didn't export any symbols.

This PR makes CMakeLists.txt set these definitions as premake4.lua does here: https://github.com/SpartanJ/efsw/blob/8dc5b857b4908adf4e73df1011a27323c8e5fef6/premake4.lua#L195