### PR TITLE
Fix typo in WatcherFSEvents.cpp

### DIFF
--- a/src/efsw/WatcherFSEvents.cpp
+++ b/src/efsw/WatcherFSEvents.cpp
@@ -157,7 +157,7 @@ void WatcherFSEvents::handleActions( std::vector<FSEvent>& events )
 			// This is a mess. But it's FSEvents faults, because shrinks events from the same file in one single event ( so there's no order for them )
 			// For example a file could have been added modified and erased, but i can't know if first was erased and then added and modified, or added, then modified and then erased.
 			// I don't know what they were thinking by doing this...
-			efDEBUG( "Event in: %s - flags: %ld\n", path.c_str(), event.Flags );
+			efDEBUG( "Event in: %s - flags: %ld\n", event.Path.c_str(), event.Flags );
 
 			if ( event.Flags & efswFSEventStreamEventFlagItemRenamed )
 			{


### PR DESCRIPTION
The library failed to build on macOS. I think that's a typo in WatcherFSEvents.cpp.
```
FAILED: CMakeFiles/efsw.dir/src/efsw/WatcherFSEvents.cpp.o 
/Library/Developer/CommandLineTools/usr/bin/c++  -DDEBUG -DEFSW_VERBOSE -I/Users/vagrant/Data/buildtrees/efsw/src/c8d343581e-3ec64856bb/src -I/Users/vagrant/Data/buildtrees/efsw/src/c8d343581e-3ec64856bb/include -fPIC -g -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk   -Wall -Wno-long-long -MD -MT CMakeFiles/efsw.dir/src/efsw/WatcherFSEvents.cpp.o -MF CMakeFiles/efsw.dir/src/efsw/WatcherFSEvents.cpp.o.d -o CMakeFiles/efsw.dir/src/efsw/WatcherFSEvents.cpp.o -c /Users/vagrant/Data/buildtrees/efsw/src/c8d343581e-3ec64856bb/src/efsw/WatcherFSEvents.cpp
/Users/vagrant/Data/buildtrees/efsw/src/c8d343581e-3ec64856bb/src/efsw/WatcherFSEvents.cpp:160:44: error: use of undeclared identifier 'path'
                        efDEBUG( "Event in: %s - flags: %ld\n", path.c_str(), event.Flags );
```