### PR TITLE
Get rid of some warnings

### DIFF
--- a/include/efsw/efsw.hpp
+++ b/include/efsw/efsw.hpp
@@ -178,6 +178,8 @@ class EFSW_API FileWatcher
 class FileWatchListener
 {
 	public:
+		virtual ~FileWatchListener() {}
+
 		/// Handles the action file action
 		/// @param watchid The watch id for the directory
 		/// @param dir The directory

--- a/src/efsw/platform/posix/FileSystemImpl.cpp
+++ b/src/efsw/platform/posix/FileSystemImpl.cpp
@@ -166,8 +166,8 @@ bool FileSystem::changeWorkingDirectory( const std::string & path )
 
 std::string FileSystem::getCurrentWorkingDirectory() {
 	char dir[PATH_MAX + 1];
-	getcwd( dir, PATH_MAX + 1 );
-	return std::string( dir );
+	char *result = getcwd( dir, PATH_MAX + 1 );
+	return result != NULL ? std::string( result ) : std::string();
 }
 
 FileInfoMap FileSystem::filesInfoFromPath( const std::string& path )


### PR DESCRIPTION
Thanks for great library. Works very well for my project.

I'd like to share some small fixes that get rid of warnings
When I use a class derived from `FileWatchListener` compiler produces this warning:
```
../3rdparty/efsw/include/efsw/efsw.hpp:178:7: error: «class efsw::FileWatchListener» has virtual functions and  non-virtual destructor [-Werror=non-virtual-dtor]
  178 | class FileWatchListener
```

And this is just when compiling library on linux
```
./3rdparty/efsw/src/efsw/platform/posix/FileSystemImpl.cpp:169:8: warning: result «char* getcwd(char*, size_t)», declared with attribute warn_unused_result, ignored [-Wunused-result]
  169 |  getcwd( dir, PATH_MAX + 1 );
```