### PR TITLE
Ensure that access to buff is thread-safe

### DIFF
--- a/src/efsw/FileWatcherInotify.cpp
+++ b/src/efsw/FileWatcherInotify.cpp
@@ -334,7 +334,7 @@ Watcher * FileWatcherInotify::watcherContainsDirectory( std::string dir )
 
 void FileWatcherInotify::run()
 {
-	static char buff[BUFF_SIZE] = {0};
+	char buff[BUFF_SIZE] = {0};
 	WatchMap::iterator wit;
 	std::list<WatcherInotify*> movedOutsideWatches;
 


### PR DESCRIPTION
`buff` must be a local object so that multiple instances of FileWatcherInotify do not share its data potentially creating a data race.