### PR TITLE
Use atomic operations for mInitOK to fix a data race

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ include(GNUInstallDirs)
 find_package(Threads REQUIRED)
 
 option (VERBOSE "Build efsw with verbose mode.")
+option (CXX11 "Build efsw with C++11")
 option (BUILD_SHARED_LIBS "Build efsw as a shared library" ON)
 option (BUILD_TEST_APP "Build the test app")
 option (EFSW_INSTALL "Add efsw install targets" ON)
@@ -43,6 +44,10 @@ target_include_directories(efsw
 
 if (VERBOSE)
 	target_compile_definitions(efsw PRIVATE EFSW_VERBOSE)
+endif()
+if (CXX11)
+	target_compile_definitions(efsw PRIVATE EFSW_USE_CXX11)
+	target_compile_features(efsw PRIVATE cxx_std_11)
 endif()
 if (BUILD_SHARED_LIBS)
 	target_compile_definitions(efsw PRIVATE EFSW_DYNAMIC EFSW_EXPORTS)

--- a/src/efsw/AtomicBool.hpp
+++ b/src/efsw/AtomicBool.hpp
@@ -1,0 +1,30 @@
+#ifndef EFSW_ATOMIC_BOOL_HPP
+#define EFSW_ATOMIC_BOOL_HPP
+
+#include <atomic>
+
+namespace efsw {
+
+class AtomicBool
+{
+	public:
+		explicit AtomicBool(bool set = false)
+			: set_(set) {}
+
+		AtomicBool& operator= (bool set) {
+			set_.store(set, std::memory_order_release);
+			return *this;
+		}
+
+		explicit operator bool() const {
+			return set_.load(std::memory_order_acquire);
+		}
+
+	private:
+		std::atomic<bool> set_;
+};
+
+}
+
+#endif
+

--- a/src/efsw/AtomicBool.hpp
+++ b/src/efsw/AtomicBool.hpp
@@ -1,7 +1,11 @@
 #ifndef EFSW_ATOMIC_BOOL_HPP
 #define EFSW_ATOMIC_BOOL_HPP
 
+#include <efsw/base.hpp>
+
+#ifdef EFSW_USE_CXX11
 #include <atomic>
+#endif
 
 namespace efsw {
 
@@ -12,16 +16,28 @@ class AtomicBool
 			: set_(set) {}
 
 		AtomicBool& operator= (bool set) {
+#ifdef EFSW_USE_CXX11
 			set_.store(set, std::memory_order_release);
+#else
+			set_ = set;
+#endif
 			return *this;
 		}
 
 		explicit operator bool() const {
+#ifdef EFSW_USE_CXX11
 			return set_.load(std::memory_order_acquire);
+#else
+			return set_;
+#endif
 		}
 
 	private:
+#ifdef EFSW_USE_CXX11
 		std::atomic<bool> set_;
+#else
+		volatile bool set_;
+#endif
 };
 
 }

--- a/src/efsw/FileWatcherImpl.cpp
+++ b/src/efsw/FileWatcherImpl.cpp
@@ -18,7 +18,7 @@ FileWatcherImpl::~FileWatcherImpl()
 
 bool FileWatcherImpl::initOK()
 {
-	return mInitOK;
+	return static_cast<bool>(mInitOK);
 }
 
 bool FileWatcherImpl::linkAllowed( const std::string& curPath, const std::string& link )

--- a/src/efsw/FileWatcherImpl.hpp
+++ b/src/efsw/FileWatcherImpl.hpp
@@ -6,6 +6,7 @@
 #include <efsw/Watcher.hpp>
 #include <efsw/Thread.hpp>
 #include <efsw/Mutex.hpp>
+#include <efsw/AtomicBool.hpp>
 
 namespace efsw {
 
@@ -45,7 +46,7 @@ class FileWatcherImpl
 		virtual bool pathInWatches( const std::string& path ) = 0;
 
 		FileWatcher *	mFileWatcher;
-		bool			mInitOK;
+		AtomicBool		mInitOK;
 		bool			mIsGeneric;
 };
 


### PR DESCRIPTION
* Requires C++11
* WARNING: ThreadSanitizer: data race (pid=1023)
  Write of size 1 at 0x7b1400000470 by main thread (mutexes: write M90):
    -0 efsw::FileWatcherGeneric::~FileWatcherGeneric() efsw/src/efsw/FileWatcherGeneric.cpp:20:10
    -1 efsw::FileWatcherGeneric::~FileWatcherGeneric() efsw/src/efsw/FileWatcherGeneric.cpp:19:1
    -2 efsw::FileWatcher::~FileWatcher() efsw/src/efsw/FileWatcher.cpp:78:2
  Previous read of size 1 at 0x7b1400000470 by thread T5:
    -0 efsw::FileWatcherGeneric::run() efsw/src/efsw/FileWatcherGeneric.cpp:151:8
    -1 efsw::Private::ThreadMemberFunc<efsw::FileWatcherGeneric>::run() efsw/src/efsw/Thread.hpp:81:22
    -2 efsw::Thread::run() efsw/src/efsw/Thread.cpp:48:15 (libidle.so+0xf8abab)
    -3 efsw::Platform::ThreadImpl::entryPoint(void*)

The reason why thread sanitizer yields a warning about this is that you are using mInitOK as atomic flag that should be visible on all threads. While (to my understanding) a relaxed memory order gets translated to an ordinary move on x86, it probably does not make any difference to a non atomic variable, however it is required for correctness on all platforms.

I do not know which C++ standard you are currently requiring, therefore the AtomicBool class probably requires an implementation for posix and Windows if you are still supporting platforms below C++11.