### PR TITLE
Use atomic operations for mInitOK to fix a data race

### DIFF
--- a/src/efsw/AtomicBool.hpp
+++ b/src/efsw/AtomicBool.hpp
@@ -1,0 +1,30 @@
+#ifndef EFSW_ATOMIC_BOOL_HPP
+#define EFSW_ATOMIC_BOOL_HPP
+
+#include <atomic>
+
+namespace efsw {
+
+class AtomicBool
+{
+	public:
+		explicit AtomicBool(bool set = false)
+			: set_(set) {}
+
+		AtomicBool& operator= (bool set) {
+			set_.store(set, std::memory_order_release);
+			return *this;
+		}
+
+		explicit operator bool() const {
+			return set_.load(std::memory_order_acquire);
+		}
+
+	private:
+		std::atomic<bool> set_;
+};
+
+}
+
+#endif
+

--- a/src/efsw/FileWatcherImpl.cpp
+++ b/src/efsw/FileWatcherImpl.cpp
@@ -18,7 +18,7 @@ FileWatcherImpl::~FileWatcherImpl()
 
 bool FileWatcherImpl::initOK()
 {
-	return mInitOK;
+	return static_cast<bool>(mInitOK);
 }
 
 bool FileWatcherImpl::linkAllowed( const std::string& curPath, const std::string& link )

--- a/src/efsw/FileWatcherImpl.hpp
+++ b/src/efsw/FileWatcherImpl.hpp
@@ -6,6 +6,7 @@
 #include <efsw/Watcher.hpp>
 #include <efsw/Thread.hpp>
 #include <efsw/Mutex.hpp>
+#include <efsw/AtomicBool.hpp>
 
 namespace efsw {
 
@@ -45,7 +46,7 @@ class FileWatcherImpl
 		virtual bool pathInWatches( const std::string& path ) = 0;
 
 		FileWatcher *	mFileWatcher;
-		bool			mInitOK;
+		AtomicBool		mInitOK;
 		bool			mIsGeneric;
 };
 


### PR DESCRIPTION
* Requires C++11
* WARNING: ThreadSanitizer: data race (pid=1023)
  Write of size 1 at 0x7b1400000470 by main thread (mutexes: write M90):
    -0 efsw::FileWatcherGeneric::~FileWatcherGeneric() efsw/src/efsw/FileWatcherGeneric.cpp:20:10
    -1 efsw::FileWatcherGeneric::~FileWatcherGeneric() efsw/src/efsw/FileWatcherGeneric.cpp:19:1
    -2 efsw::FileWatcher::~FileWatcher() efsw/src/efsw/FileWatcher.cpp:78:2
  Previous read of size 1 at 0x7b1400000470 by thread T5:
    -0 efsw::FileWatcherGeneric::run() efsw/src/efsw/FileWatcherGeneric.cpp:151:8
    -1 efsw::Private::ThreadMemberFunc<efsw::FileWatcherGeneric>::run() efsw/src/efsw/Thread.hpp:81:22
    -2 efsw::Thread::run() efsw/src/efsw/Thread.cpp:48:15 (libidle.so+0xf8abab)
    -3 efsw::Platform::ThreadImpl::entryPoint(void*)