### PR TITLE
CMake: fix export using the root project's name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ endif()
 
 include(CMakePackageConfigHelpers)
 
-set(packageDestDir "${CMAKE_INSTALL_LIBDIR}/cmake/${CMAKE_PROJECT_NAME}")
+set(packageDestDir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
 configure_package_config_file(
 	${CMAKE_CURRENT_SOURCE_DIR}/efswConfig.cmake.in
@@ -135,7 +135,7 @@ configure_package_config_file(
 	NO_CHECK_REQUIRED_COMPONENTS_MACRO
 )
 
-export(TARGETS efsw NAMESPACE efsw:: FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/${CMAKE_PROJECT_NAME}Targets.cmake)
+export(TARGETS efsw NAMESPACE efsw:: FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake)
 
 if(EFSW_INSTALL)
   install(TARGETS efsw EXPORT efswExport
@@ -143,15 +143,15 @@ if(EFSW_INSTALL)
   	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   )
-  
+
   install (
   	FILES
   		include/efsw/efsw.h include/efsw/efsw.hpp
   		src/efsw/base.hpp src/efsw/System.hpp src/efsw/FileSystem.hpp
   	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/efsw
   )
-  
-  install(EXPORT efswExport NAMESPACE efsw:: DESTINATION "${packageDestDir}" FILE ${CMAKE_PROJECT_NAME}Targets.cmake)
+
+  install(EXPORT efswExport NAMESPACE efsw:: DESTINATION "${packageDestDir}" FILE ${PROJECT_NAME}Targets.cmake)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/efswConfig.cmake DESTINATION "${packageDestDir}")
 endif()
 


### PR DESCRIPTION
Hi,

The CMake export used the CMAKE_PROJECT_NAME variable instead of PROJECT_NAME, which leads to the generated files having incorrect names when efsw is used as a subproject of another CMake-based project (ie. `efswConfig.cmake` was instead named `[root project name].cmake`).