### PR TITLE
CMake: fix export template using the root project's name

### DIFF
--- a/efswConfig.cmake.in
+++ b/efswConfig.cmake.in
@@ -4,4 +4,4 @@
 
 @DEPENDENCIES_SECTION@
 
-include("${CMAKE_CURRENT_LIST_DIR}/@CMAKE_PROJECT_NAME@Targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Hi again,

This is a followup to PR https://github.com/SpartanJ/efsw/pull/132
There was a remaining reference to the CMAKE_PROJECT_NAME variable in the export script template, so the main import script and the *Targets.cmake script did not match.