### PR TITLE
Don't install internal headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,6 @@ if(EFSW_INSTALL)
   install (
   	FILES
   		include/efsw/efsw.h include/efsw/efsw.hpp
-  		src/efsw/base.hpp src/efsw/System.hpp src/efsw/FileSystem.hpp
   	DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/efsw
   )
 


### PR DESCRIPTION
it makes little sense to expore internal headers such as System.hpp and FileSystem.hpp (which require other files that aren't exported anyway).