### PR TITLE
Recursive inotify watches should maintain the same root ID

### DIFF
--- a/src/efsw/WatcherInotify.hpp
+++ b/src/efsw/WatcherInotify.hpp
@@ -16,6 +16,7 @@ class WatcherInotify : public Watcher
 		bool inParentTree( WatcherInotify * parent );
 
 		WatcherInotify * Parent;
+		WatchID	InotifyID;
 
 		FileInfo DirInfo;
 };


### PR DESCRIPTION
I assume it is intended that the `WatchID` passed to `handleFileAction` should match that originally returned by `addWatch`.

When using the inotify watcher recursively, it creates child inotify watches for each folder.
The `WatchID` passed to `handleFileAction` will currently be that of the underlying child inotify watcher that triggers it, and not the ID originally returned by efsw's `addWatch` (which will be the root directory inotify watcher ID).

This will make the IDs of the child inotify watchers opaque to users of efsw by storing it in a separate member variable, and then maintaining the parent/root ID while creating child watchers.
