### PR TITLE
reslove file watcher inotfiy destructor deadlock

### DIFF
--- a/src/efsw/FileWatcherInotify.hpp
+++ b/src/efsw/FileWatcherInotify.hpp
@@ -57,6 +57,7 @@ class FileWatcherInotify : public FileWatcherImpl {
 	Mutex mWatchesLock;
 	Mutex mRealWatchesLock;
 	Mutex mInitLock;
+	bool mIsTakingAction;
 	std::vector<std::pair<WatcherInotify*, std::string>> mMovedOutsideWatches;
 
 	WatchID addWatch( const std::string& directory, FileWatchListener* watcher, bool recursive,


### PR DESCRIPTION
There is deadlock between main thread executing destructor and hand action thread.
So this PR try create a new bool member property to mark hand action thread working or not. 
Besides, file watcher destructor will wait until action thread finished, which gurantees backgroud thread could be terminated successfully.