### PR TITLE
[WIP]fix invalid watcher iterator while found before removing it from map …

### DIFF
--- a/src/efsw/FileWatcherInotify.cpp
+++ b/src/efsw/FileWatcherInotify.cpp
@@ -341,12 +341,9 @@ void FileWatcherInotify::run() {
 					struct inotify_event* pevent = (struct inotify_event*)&buff[i];
 
 					{
-						{
-							Lock lock( mWatchesLock );
+						Lock lock( mWatchesLock );
 
-							wit = mWatches.find( pevent->wd );
-						}
-
+						wit = mWatches.find( pevent->wd );
 						if ( wit != mWatches.end() ) {
 							handleAction( wit->second, (char*)pevent->name, pevent->mask );
 
@@ -382,6 +379,7 @@ void FileWatcherInotify::run() {
 						if ( pevent->mask & IN_MOVED_FROM )
 							prevOldFileName = std::string( (char*)pevent->name );
 					}
+
 
 					i += sizeof( struct inotify_event ) + pevent->len;
 				}


### PR DESCRIPTION
```cpp
{
{
Lock lock( mWatchesLock);
wit = mWatches.find( pevent->wd);
}
wit->second;
}
```
iterator `wit` might be an invalid if this iterator has been removed from map collection after `find` method.
