### PR TITLE
Fix issue with ReadDirectoryChangesW API on Win32 when buffer overflows

### DIFF
--- a/src/efsw/WatcherWin32.cpp
+++ b/src/efsw/WatcherWin32.cpp
@@ -10,7 +10,8 @@ namespace efsw {
 
 /// Unpacks events and passes them to a user defined callback.
 void CALLBACK WatchCallback( DWORD dwNumberOfBytesTransfered, LPOVERLAPPED lpOverlapped ) {
-	if ( dwNumberOfBytesTransfered == 0 || NULL == lpOverlapped ) {
+
+	if ( NULL == lpOverlapped ) {
 		return;
 	}
 
@@ -18,6 +19,14 @@ void CALLBACK WatchCallback( DWORD dwNumberOfBytesTransfered, LPOVERLAPPED lpOve
 	WatcherStructWin32* tWatch = (WatcherStructWin32*)lpOverlapped;
 	WatcherWin32* pWatch = tWatch->Watch;
 	size_t offset = 0;
+
+	if ( dwNumberOfBytesTransfered == 0 ) {
+		if ( nullptr != pWatch && !pWatch->StopNow ) {
+			RefreshWatch( tWatch );
+		} else {
+			return;
+		}
+	}
 
 	do {
 		bool skip = false;


### PR DESCRIPTION
On Win32, when using the ReadDirectoryChangesW API to monitor file system changes, if the buffer used to receive system change messages overflows, ReadDirectoryChangesW will still return true but will discard all the content of the buffer. In this case, the `lpBytesReturned` parameter will be zero. If ReadDirectoryChangesW is not called again after this, we can no longer get new change information.