### PR TITLE
Add call to FileSystem::precomposeFileName for oldFilename on sendFil…

### DIFF
--- a/src/efsw/WatcherFSEvents.cpp
+++ b/src/efsw/WatcherFSEvents.cpp
@@ -66,7 +66,7 @@ void WatcherFSEvents::sendFileAction( WatchID watchid, const std::string& dir,
 									  const std::string& filename, Action action,
 									  std::string oldFilename ) {
 	Listener->handleFileAction( watchid, FileSystem::precomposeFileName( dir ),
-								FileSystem::precomposeFileName( filename ), action, oldFilename );
+								FileSystem::precomposeFileName( filename ), action, FileSystem::precomposeFileName( oldFilename ) );
 }
 
 void WatcherFSEvents::handleAddModDel( const Uint32& flags, const std::string& path,


### PR DESCRIPTION
…eAction @ WatcherFSEvents.cpp

Perform the same operation (FileSystem::precomposeFileName) on oldFilename as on dir and filename in order to get the same result when handling any file action, especially file renaming using accents.