### PR TITLE
fix clang-msvc backend cmake error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,8 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
 	)
 endif()
 
-if(MSVC)
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR
+	(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC"))
 	target_compile_definitions(efsw PRIVATE _SCL_SECURE_NO_WARNINGS)
 else()
 	target_compile_options(efsw PRIVATE -Wall -Wno-long-long -fPIC)


### PR DESCRIPTION
when compiler is clang but backend is MSVC, cmake config will failed due to check MSVC failed(`-fPIC` will add to clang):
my compiler:
![image](https://github.com/SpartanJ/efsw/assets/35966247/3a3ffe2d-120d-4662-9e95-90566e8da39f)

use `CMAKE_CXX_COMPILER_ID` and `CMAKE_CXX_SIMULATE_ID` to check clang backend.