### PR TITLE
Replace hardcoded inotify.h paths with find_path in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,8 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 		src/efsw/WatcherInotify.cpp
 	)
 
-	if(NOT EXISTS "/usr/include/sys/inotify.h" AND NOT EXISTS "/usr/local/include/sys/inotify.h")
+	find_path(EFSW_INOTIFY_H NAMES sys/inotify.h NO_CACHE)
+	if(EFSW_INOTIFY_H STREQUAL "EFSW_INOTIFY_H-NOTFOUND")
 		target_compile_definitions(efsw PRIVATE EFSW_INOTIFY_NOSYS)
 	endif()
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")


### PR DESCRIPTION
On my system (ubuntu 22.04) its found at `/usr/include/x86_64-linux-gnu/sys/inotify.h`