### PR TITLE
Fixup cmake exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,9 @@ configure_package_config_file(
 )
 
 export(TARGETS efsw NAMESPACE efsw:: FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake)
-export(TARGETS efsw-static NAMESPACE efsw:: FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}-staticTargets.cmake)
+if(BUILD_STATIC_LIBS)
+	export(TARGETS efsw-static NAMESPACE efsw:: APPEND FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake)
+endif()
 
 if(EFSW_INSTALL)
 	install(TARGETS efsw EXPORT efswExport
@@ -173,25 +175,16 @@ if(EFSW_INSTALL)
 		DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/efsw
 	)
 
-	install(EXPORT efswExport NAMESPACE efsw:: DESTINATION "${packageDestDir}" FILE ${PROJECT_NAME}Targets.cmake)
-	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/efswConfig.cmake DESTINATION "${packageDestDir}")
-
-	if(BUILD_SHARED_LIBS)
+	if(BUILD_STATIC_LIBS)
 		install(TARGETS efsw-static EXPORT efswExport
 			LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 			ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 			RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 		)
-
-		install(
-			FILES
-			include/efsw/efsw.h include/efsw/efsw.hpp
-			DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/efsw
-		)
-
-		install(EXPORT efswExport NAMESPACE efsw:: DESTINATION "${packageDestDir}" FILE ${PROJECT_NAME}-staticTargets.cmake)
-		install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/efswConfig.cmake DESTINATION "${packageDestDir}")
 	endif()
+
+	install(EXPORT efswExport NAMESPACE efsw:: DESTINATION "${packageDestDir}" FILE ${PROJECT_NAME}Targets.cmake)
+	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/efswConfig.cmake DESTINATION "${packageDestDir}")
 endif()
 
 if(BUILD_TEST_APP)

--- a/efswConfig.cmake.in
+++ b/efswConfig.cmake.in
@@ -3,5 +3,8 @@
 @PACKAGE_INIT@
 
 @DEPENDENCIES_SECTION@
+include(CMakeFindDependencyMacro)
+
+find_dependency(Threads)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
* Add missing find_dependency calls to efswConfig.cmake.in
* Removed duplicated efswTargets.cmake and efsw-staticTargets.cmake generation both of them contained all targets so -static file was dropped (this is the safe approach that preserves current behavior even if this isn't what was intended)