### PR TITLE
Fix MSVC Warning C4834

### DIFF
--- a/src/efsw/Debug.hpp
+++ b/src/efsw/Debug.hpp
@@ -49,8 +49,10 @@ void efPRINTC( unsigned int cond, const char* format, ... );
 #define efDEBUGC( cond, format, args... ) \
 	{}
 #else
-#define efDEBUG
-#define efDEBUGC
+#define efDEBUG( ... ) \
+	{}
+#define efDEBUGC( ... ) \
+	{}
 #endif
 
 #endif


### PR DESCRIPTION
Fix efDEBUG macro definition to disable MSVC Warning C4834 for [[no discard]] arguments.