### PR TITLE
Fix issue #181 (should validate cfInode)

### DIFF
--- a/src/efsw/FileWatcherFSEvents.cpp
+++ b/src/efsw/FileWatcherFSEvents.cpp
@@ -84,10 +84,13 @@ void FileWatcherFSEvents::FSEventCallback( ConstFSEventStreamRef streamRef, void
 				CFDictionaryGetValue( pathInfoDict, kFSEventStreamEventExtendedDataPathKey ) );
 			CFNumberRef cfInode = static_cast<CFNumberRef>(
 				CFDictionaryGetValue( pathInfoDict, kFSEventStreamEventExtendedFileIDKey ) );
-			unsigned long inode = 0;
-			CFNumberGetValue( cfInode, kCFNumberLongType, &inode );
-			events.push_back( FSEvent( convertCFStringToStdString( path ), (long)eventFlags[i],
-									   (Uint64)eventIds[i], inode ) );
+
+			if ( cfInode ) {
+				unsigned long inode = 0;
+				CFNumberGetValue( cfInode, kCFNumberLongType, &inode );
+				events.push_back( FSEvent( convertCFStringToStdString( path ), (long)eventFlags[i],
+										   (Uint64)eventIds[i], inode ) );
+			}
 		} else {
 			events.push_back( FSEvent( std::string( ( (char**)eventPaths )[i] ),
 									   (long)eventFlags[i], (Uint64)eventIds[i] ) );


### PR DESCRIPTION
`CFNumberGetValue` will crash if `cfInode` is nullptr, which can occur when events lack inode information (e.g., file system events).
I'm not certain which exact event triggers this, but an easy way to reproduce the crash is to create a folder with many files and then delete it.
(In my environment, I created a folder with 1000 files and used rm -r to remove it.)