### PR TITLE
Notify about missed event on Windows, MacOs & Linux.

### DIFF
--- a/include/efsw/efsw.hpp
+++ b/include/efsw/efsw.hpp
@@ -245,6 +245,12 @@ class FileWatchListener {
 	virtual void handleFileAction( WatchID watchid, const std::string& dir,
 								   const std::string& filename, Action action,
 								   std::string oldFilename = "" ) = 0;
+	
+	/// Handles that have missed file actions
+	/// @param watchid The watch id for the directory
+	/// @param dir The directory
+	virtual void handleMissedFileActions( WatchID /*watchid*/,
+										  const std::string& /*dir*/ ) {};
 };
 
 /// Optional, typically platform specific parameter for customization of a watcher.

--- a/src/efsw/FileWatcherInotify.cpp
+++ b/src/efsw/FileWatcherInotify.cpp
@@ -512,7 +512,9 @@ void FileWatcherInotify::handleAction( Watcher* watch, const std::string& filena
 
 	std::string fpath( watch->Directory + filename );
 
-	if ( ( IN_CLOSE_WRITE & action ) || ( IN_MODIFY & action ) ) {
+	if ( IN_Q_OVERFLOW & action ) {
+		watch->Listener->handleMissedFileActions( watch->ID, watch->Directory );
+	} else if ( ( IN_CLOSE_WRITE & action ) || ( IN_MODIFY & action ) ) {
 		watch->Listener->handleFileAction( watch->ID, watch->Directory, filename,
 										   Actions::Modified );
 	} else if ( IN_MOVED_TO & action ) {

--- a/src/efsw/WatcherFSEvents.hpp
+++ b/src/efsw/WatcherFSEvents.hpp
@@ -78,6 +78,8 @@ class WatcherFSEvents : public Watcher {
 
 	void sendFileAction( WatchID watchid, const std::string& dir, const std::string& filename,
 						 Action action, std::string oldFilename = "" );
+
+	void sendMissedFileActions( WatchID watchid, const std::string& dir);
 };
 
 } // namespace efsw

--- a/src/efsw/WatcherWin32.cpp
+++ b/src/efsw/WatcherWin32.cpp
@@ -1,4 +1,5 @@
 #include <efsw/Debug.hpp>
+#include <efsw/FileSystem.hpp>
 #include <efsw/String.hpp>
 #include <efsw/WatcherWin32.hpp>
 
@@ -162,6 +163,10 @@ void CALLBACK WatchCallback( DWORD dwNumberOfBytesTransfered, LPOVERLAPPED lpOve
 
 	if ( dwNumberOfBytesTransfered == 0 ) {
 		if ( nullptr != pWatch && !pWatch->StopNow ) {
+			/// Missed file actions due to buffer overflowed
+			std::string dir = pWatch->DirName;
+			FileSystem::dirRemoveSlashAtEnd( dir );
+			pWatch->Listener->handleMissedFileActions( pWatch->ID, dir );
 			RefreshWatch( tWatch );
 		} else {
 			return;


### PR DESCRIPTION
Hi. We use your library for monitoring changes in our repository on different OS. 
And we noticed that in some situation Windows OS loses file events due to buffer overflowed. In this situation client should  resync file tree manually. So I added listener notification to inform client about missing file actions.

For information: chromium code do it in the same way
https://source.chromium.org/chromium/chromium/src/+/main:content/browser/file_system_access/file_path_watcher/file_path_watcher_win.cc;l=485;drc=8d1bf30bd5eccfc602479995ba9e7d886c93d1b5;bpv=0;bpt=1

https://source.chromium.org/chromium/chromium/src/+/main:content/browser/file_system_access/file_path_watcher/file_path_watcher_win.cc;drc=8d1bf30bd5eccfc602479995ba9e7d886c93d1b5;bpv=0;bpt=1;l=563