### PR TITLE
Fix build with libcxx 20.1.8

### DIFF
--- a/src/efsw/FileSystem.cpp
+++ b/src/efsw/FileSystem.cpp
@@ -2,6 +2,7 @@
 #include <efsw/FileSystem.hpp>
 #include <efsw/platform/platformimpl.hpp>
 #include <climits>
+#include <cstdlib>
 
 #if EFSW_OS == EFSW_OS_MACOSX
 #include <CoreFoundation/CoreFoundation.h>


### PR DESCRIPTION
This include is required for realpath since libcxx about version 20.1.8.
```
/root/efsw/src/efsw/FileSystem.cpp:148:2: error: use of undeclared identifier 'realpath'
  148 |         realpath( path.c_str(), &dir[0] );
      |         ^
1 error generated.
```