### PR TITLE
macOS: drain FSEvents dispatch queue in WatcherFSEvents destructor

### DIFF
--- a/src/efsw/WatcherFSEvents.cpp
+++ b/src/efsw/WatcherFSEvents.cpp
@@ -8,13 +8,21 @@
 namespace efsw {
 
 WatcherFSEvents::WatcherFSEvents() :
-	Watcher(), FWatcher( NULL ), FSStream( NULL ), WatcherGen( NULL ) {}
+	Watcher(), FWatcher( NULL ), FSStream( NULL ), DispatchQueue( NULL ), WatcherGen( NULL ) {}
 
 WatcherFSEvents::~WatcherFSEvents() {
 	if ( NULL != FSStream ) {
 		FSEventStreamStop( FSStream );
 		FSEventStreamInvalidate( FSStream );
+		if ( NULL != DispatchQueue ) {
+			dispatch_sync( DispatchQueue, ^{} );
+		}
 		FSEventStreamRelease( FSStream );
+	}
+
+	if ( NULL != DispatchQueue ) {
+		dispatch_release( DispatchQueue );
+		DispatchQueue = NULL;
 	}
 
 	efSAFE_DELETE( WatcherGen );
@@ -43,13 +51,13 @@ void WatcherFSEvents::init() {
 	ctx.release = NULL;
 	ctx.copyDescription = NULL;
 
-	dispatch_queue_t queue = dispatch_queue_create( NULL, NULL );
+	DispatchQueue = dispatch_queue_create( NULL, NULL );
 
 	FSStream =
 		FSEventStreamCreate( kCFAllocatorDefault, &FileWatcherFSEvents::FSEventCallback, &ctx,
 							 CFDirectoryArray, kFSEventStreamEventIdSinceNow, 0., streamFlags );
 
-	FSEventStreamSetDispatchQueue( FSStream, queue );
+	FSEventStreamSetDispatchQueue( FSStream, DispatchQueue );
 
 	FSEventStreamStart( FSStream );
 

--- a/src/efsw/WatcherFSEvents.hpp
+++ b/src/efsw/WatcherFSEvents.hpp
@@ -64,6 +64,7 @@ class WatcherFSEvents : public Watcher {
 
 	Atomic<FileWatcherFSEvents*> FWatcher;
 	FSEventStreamRef FSStream;
+	dispatch_queue_t DispatchQueue;
 	Uint64 ModifiedFlags{ efswFSEventsModified };
 	bool SanitizeEvents{ false };
 


### PR DESCRIPTION
## Problem

`WatcherFSEvents::~WatcherFSEvents()` invalidates and releases the
`FSEventStreamRef`, then deletes `WatcherGen`. None of those calls
synchronously drain callbacks already dispatched onto the stream's
`dispatch_queue_t`. An in-flight `FSEventCallback` running on a GCD
worker thread can still be reading `DirsChanged`, `WatcherGen`,
`Listener`, etc. while the destructor is freeing them — a data race
that manifests as a use-after-free / heap corruption crashing inside
`libsystem_platform`'s `_platform_memmove` / `_platform_memset` when
unrelated heap operations later run.

## Reproduction

Caught with ThreadSanitizer in our application's filesystem-watching
integration tests on macOS arm64 (built with clang 21,
`-fsanitize=thread`, runtime swapped to Apple's CLT TSan dylib due to
an unrelated nix compiler-rt issue on macOS 26).

TSan report (abbreviated):

```
WARNING: ThreadSanitizer: data race
  Read of size 8 by main thread:
    #0 efsw::WatcherFSEvents::~WatcherFSEvents()  WatcherFSEvents.cpp
    #1 efsw::FileWatcherFSEvents::removeWatch(long)  FileWatcherFSEvents.cpp
    ...

  Previous write of size 8 by thread T1:
    #0 efsw::WatcherFSEvents::process()  WatcherFSEvents.cpp
    #1 efsw::FileWatcherFSEvents::FSEventCallback(...)  FileWatcherFSEvents.cpp
    #2 implementation_callback_rpc      (FSEvents.framework)
    #3 _dispatch_client_callout         (libdispatch.dylib)

  Thread T1 is a GCD worker thread
```

Across 30 stress iterations of our test suite (each running 5–9
real-disk filewatcher tests under TSan), the race fired **93 times**
on the unpatched code, plus three runtime SEGVs in
`_platform_memmove`. With this patch applied: **0 hits, 0 SEGVs**.

## Fix

Apple's documented FSEventStream shutdown sequence on a dispatch
queue is `Stop → Invalidate → drain queue → Release`. `Invalidate`
prevents *new* callbacks from being scheduled but does not wait for
ones already in flight, so a `dispatch_sync(queue, ^{})` barrier is
required before releasing the stream and tearing down state the
callback may still be reading.

This patch:

- Stores the dispatch queue created in `init()` as a member
  (`DispatchQueue`) so the destructor can reach it.
- Inserts a `dispatch_sync(DispatchQueue, ^{})` barrier between
  `FSEventStreamInvalidate` and `FSEventStreamRelease`.
- Releases the queue itself via `dispatch_release` after the stream
  is gone (we own one reference from `dispatch_queue_create`).

No behavioural change for callers; just plugs the teardown race.