### PR TITLE
Properly support emoji filenames

### DIFF
--- a/src/efsw/String.cpp
+++ b/src/efsw/String.cpp
@@ -207,14 +207,8 @@ std::string String::toUtf8() const {
 	std::string output;
 	output.reserve( mString.length() + 1 );
 
-// Convert
-#if WCHAR_MAX == 0xFFFF
-	// Windows (UTF-16)
-	Utf<16>::toUtf8( mString.begin(), mString.end(), std::back_inserter( output ) );
-#else
-	// Linux (UTF-32)
-	Utf<32>::toUtf8( mString.begin(), mString.end(), std::back_inserter( output ) );
-#endif
+	// Convert
+	Utf32::toUtf8( mString.begin(), mString.end(), std::back_inserter( output ) );
 
 	return output;
 }

--- a/src/efsw/String.cpp
+++ b/src/efsw/String.cpp
@@ -207,8 +207,14 @@ std::string String::toUtf8() const {
 	std::string output;
 	output.reserve( mString.length() + 1 );
 
-	// Convert
-	Utf32::toUtf8( mString.begin(), mString.end(), std::back_inserter( output ) );
+// Convert
+#if WCHAR_MAX == 0xFFFF
+	// Windows (UTF-16)
+	Utf<16>::toUtf8( mString.begin(), mString.end(), std::back_inserter( output ) );
+#else
+	// Linux (UTF-32)
+	Utf<32>::toUtf8( mString.begin(), mString.end(), std::back_inserter( output ) );
+#endif
 
 	return output;
 }

--- a/src/efsw/Utf.hpp
+++ b/src/efsw/Utf.hpp
@@ -650,6 +650,20 @@ template <> class Utf<32> {
 	template <typename In> static Uint32 DecodeWide( In input );
 
 	////////////////////////////////////////////////////////////
+	/// \brief Decode wide characters to UTF-32
+	///
+	/// This function does not exist in other specializations
+	/// of efsw::Utf<>, it is defined for convenience (it is used by
+	/// several other conversion functions).
+	///
+	/// \param input Input wide character
+	///
+	/// \return Converted character
+	///
+	////////////////////////////////////////////////////////////
+	template <typename In> static Uint32 DecodeWide( In& it, In end );
+
+	////////////////////////////////////////////////////////////
 	/// \brief Encode a single UTF-32 character to ANSI
 	///
 	/// This function does not exist in other specializations

--- a/src/efsw/Utf.inl
+++ b/src/efsw/Utf.inl
@@ -403,7 +403,7 @@ Out Utf<32>::FromAnsi( In begin, In end, Out output, const std::locale& locale )
 
 template <typename In, typename Out> Out Utf<32>::FromWide( In begin, In end, Out output ) {
 	while ( begin < end )
-		*output++ = DecodeWide( *begin++ );
+		*output++ = DecodeWide( begin, end );
 
 	return output;
 }
@@ -499,13 +499,76 @@ template <typename In> Uint32 Utf<32>::DecodeAnsi( In input, const std::locale& 
 }
 
 template <typename In> Uint32 Utf<32>::DecodeWide( In input ) {
-	// The encoding of wide characters is not well defined and is left to the system;
-	// however we can safely assume that it is UCS-2 on Windows and
-	// UCS-4 on Unix systems.
-	// In both cases, a simple copy is enough (UCS-2 is a subset of UCS-4,
-	// and UCS-4 *is* UTF-32).
+	// We have no context to combine surrogate pairs, so the only safe thing on a 16‑bit wchar_t
+	// platform is to reject surrogate code units.
+	const Uint32 replacement = 0xFFFD;
 
-	return input;
+	switch ( sizeof( wchar_t ) ) {
+		case 2: {
+			const Uint32 w = static_cast<Uint32>( input );
+			if ( w >= 0xD800u && w <= 0xDFFFu )
+				return replacement; // Cannot form a full code point here
+			return w;
+		}
+		case 4: {
+			const Uint32 code = static_cast<Uint32>( input );
+			if ( code > 0x10FFFFu || ( code >= 0xD800u && code <= 0xDFFFu ) )
+				return replacement;
+			return code;
+		}
+	}
+
+	return replacement;
+}
+
+template <typename In> Uint32 Utf<32>::DecodeWide( In& it, In end ) {
+	// The encoding of wide characters is not well defined and is left to the system;
+	// Previously we assumed
+	// UCS-2 on Windows and UCS-4 on Unix and just copied wchar_t to UTF-32,
+	// which broke for characters outside the BMP (surrogate pairs were copied
+	// as invalid code points). Treat 16-bit wchar_t as UTF-16 (handling
+	// surrogates) and 32-bit wchar_t as UTF-32 with validation, producing valid
+	// Unicode values in all cases.
+
+	const Uint32 replacement = 0xFFFD;
+
+	switch ( sizeof( wchar_t ) ) {
+		case 2: {
+			const Uint32 w1 = static_cast<Uint32>( *it++ );
+
+			if ( w1 >= 0xD800u && w1 <= 0xDBFFu ) {
+				// High surrogate
+				if ( it != end ) {
+					const Uint32 w2 = static_cast<Uint32>( *it );
+					if ( w2 >= 0xDC00u && w2 <= 0xDFFFu ) {
+						// Valid surrogate pair
+						++it;
+						return 0x10000u + ( ( w1 - 0xD800u ) << 10 ) + ( w2 - 0xDC00u );
+					}
+				}
+				// Unpaired or invalid second unit
+				return replacement;
+			} else if ( w1 >= 0xDC00u && w1 <= 0xDFFFu ) {
+				// Unpaired low surrogate
+				return replacement;
+			} else {
+				// BMP code point
+				return w1;
+			}
+		}
+		case 4: {
+			const Uint32 code = static_cast<Uint32>( *it++ );
+
+			// Validate scalar value
+			if ( code > 0x10FFFFu || ( code >= 0xD800u && code <= 0xDFFFu ) ) {
+				return replacement;
+			}
+
+			return code;
+		}
+	}
+
+	return replacement;
 }
 
 template <typename Out>
@@ -557,7 +620,13 @@ Out Utf<32>::EncodeWide( Uint32 codepoint, Out output, wchar_t replacement ) {
 
 	switch ( sizeof( wchar_t ) ) {
 		case 4: {
-			*output++ = static_cast<wchar_t>( codepoint );
+
+			// Validate code point for UCS-4
+			if ( codepoint <= 0x10FFFF && !( codepoint >= 0xD800 && codepoint <= 0xDFFF ) ) {
+				*output++ = static_cast<wchar_t>( codepoint );
+			} else if ( replacement ) {
+				*output++ = replacement;
+			}
 			break;
 		}
 
@@ -568,8 +637,9 @@ Out Utf<32>::EncodeWide( Uint32 codepoint, Out output, wchar_t replacement ) {
 					*output++ = static_cast<wchar_t>( codepoint );
 				} else {
 					// Invalid code point -> replacement
-					if ( replacement )
+					if ( replacement ) {
 						*output++ = replacement;
+					}
 				}
 			} else if ( codepoint <= 0x10FFFF ) {
 				// Encode surrogate pair
@@ -582,8 +652,9 @@ Out Utf<32>::EncodeWide( Uint32 codepoint, Out output, wchar_t replacement ) {
 				*output++ = low;
 			} else {
 				// Invalid Unicode range
-				if ( replacement )
+				if ( replacement ) {
 					*output++ = replacement;
+				}
 			}
 			break;
 		}

--- a/src/efsw/Utf.inl
+++ b/src/efsw/Utf.inl
@@ -502,23 +502,19 @@ template <typename In> Uint32 Utf<32>::DecodeWide( In input ) {
 	// We have no context to combine surrogate pairs, so the only safe thing on a 16‑bit wchar_t
 	// platform is to reject surrogate code units.
 	const Uint32 replacement = 0xFFFD;
+	const Uint32 code = static_cast<Uint32>( input );
 
-	switch ( sizeof( wchar_t ) ) {
-		case 2: {
-			const Uint32 w = static_cast<Uint32>( input );
-			if ( w >= 0xD800u && w <= 0xDFFFu )
-				return replacement; // Cannot form a full code point here
-			return w;
-		}
-		case 4: {
-			const Uint32 code = static_cast<Uint32>( input );
-			if ( code > 0x10FFFFu || ( code >= 0xD800u && code <= 0xDFFFu ) )
-				return replacement;
-			return code;
-		}
-	}
+#if WCHAR_MAX == 0xFFFF
+	// UTF-16: Reject surrogate code units
+	if ( code >= 0xD800u && code <= 0xDFFFu )
+		return replacement; // Cannot form a full code point here
+#else
+	// UTF-32: emit single wchar_t codepoint
+	if ( code > 0x10FFFFu || ( code >= 0xD800u && code <= 0xDFFFu ) )
+		return replacement;
+#endif
 
-	return replacement;
+	return code;
 }
 
 template <typename In> Uint32 Utf<32>::DecodeWide( In& it, In end ) {
@@ -532,43 +528,40 @@ template <typename In> Uint32 Utf<32>::DecodeWide( In& it, In end ) {
 
 	const Uint32 replacement = 0xFFFD;
 
-	switch ( sizeof( wchar_t ) ) {
-		case 2: {
-			const Uint32 w1 = static_cast<Uint32>( *it++ );
+#if WCHAR_MAX == 0xFFFF
+	// UTF-16
+	const Uint32 w1 = static_cast<Uint32>( *it++ );
 
-			if ( w1 >= 0xD800u && w1 <= 0xDBFFu ) {
-				// High surrogate
-				if ( it != end ) {
-					const Uint32 w2 = static_cast<Uint32>( *it );
-					if ( w2 >= 0xDC00u && w2 <= 0xDFFFu ) {
-						// Valid surrogate pair
-						++it;
-						return 0x10000u + ( ( w1 - 0xD800u ) << 10 ) + ( w2 - 0xDC00u );
-					}
-				}
-				// Unpaired or invalid second unit
-				return replacement;
-			} else if ( w1 >= 0xDC00u && w1 <= 0xDFFFu ) {
-				// Unpaired low surrogate
-				return replacement;
-			} else {
-				// BMP code point
-				return w1;
+	if ( w1 >= 0xD800u && w1 <= 0xDBFFu ) {
+		// High surrogate
+		if ( it != end ) {
+			const Uint32 w2 = static_cast<Uint32>( *it );
+			if ( w2 >= 0xDC00u && w2 <= 0xDFFFu ) {
+				// Valid surrogate pair
+				++it;
+				return 0x10000u + ( ( w1 - 0xD800u ) << 10 ) + ( w2 - 0xDC00u );
 			}
 		}
-		case 4: {
-			const Uint32 code = static_cast<Uint32>( *it++ );
+		// Unpaired or invalid second unit
+		return replacement;
+	} else if ( w1 >= 0xDC00u && w1 <= 0xDFFFu ) {
+		// Unpaired low surrogate
+		return replacement;
+	} else {
+		// BMP code point
+		return w1;
+	}
+#else
+	// UTF-32: emit single wchar_t codepoint
+	const Uint32 code = static_cast<Uint32>( *it++ );
 
-			// Validate scalar value
-			if ( code > 0x10FFFFu || ( code >= 0xD800u && code <= 0xDFFFu ) ) {
-				return replacement;
-			}
-
-			return code;
-		}
+	// Validate scalar value
+	if ( code > 0x10FFFFu || ( code >= 0xD800u && code <= 0xDFFFu ) ) {
+		return replacement;
 	}
 
-	return replacement;
+	return code;
+#endif
 }
 
 template <typename Out>
@@ -613,52 +606,51 @@ Out Utf<32>::EncodeAnsi( Uint32 codepoint, Out output, char replacement,
 template <typename Out>
 Out Utf<32>::EncodeWide( Uint32 codepoint, Out output, wchar_t replacement ) {
 	// The encoding of wide characters is not well defined and is left to the system;
-	// however we can safely assume that it is UCS-2 on Windows and
-	// UCS-4 on Unix systems.
-	// For UCS-2 we need to check if the source characters fits in (UCS-2 is a subset of UCS-4).
-	// For UCS-4 we can do a direct copy (UCS-4 *is* UTF-32).
+	// Previously we assumed
+	// UCS-2 on Windows and UCS-4 on Unix and just copied wchar_t to UTF-32,
+	// which broke for characters outside the BMP (surrogate pairs were copied
+	// as invalid code points). Treat 16-bit wchar_t as UTF-16 (handling
+	// surrogates) and 32-bit wchar_t as UTF-32 with validation, producing valid
+	// Unicode values in all cases.
 
-	switch ( sizeof( wchar_t ) ) {
-		case 4: {
-
-			// Validate code point for UCS-4
-			if ( codepoint <= 0x10FFFF && !( codepoint >= 0xD800 && codepoint <= 0xDFFF ) ) {
-				*output++ = static_cast<wchar_t>( codepoint );
-			} else if ( replacement ) {
+#if WCHAR_MAX == 0xFFFF
+	// UTF-16
+	if ( codepoint <= 0xFFFF ) {
+		// Exclude surrogate range
+		if ( codepoint < 0xD800 || codepoint > 0xDFFF ) {
+			*output++ = static_cast<wchar_t>( codepoint );
+		} else {
+			// Invalid code point -> replacement
+			if ( replacement ) {
 				*output++ = replacement;
 			}
-			break;
 		}
+	} else if ( codepoint <= 0x10FFFF ) {
+		// Encode surrogate pair
+		codepoint -= 0x10000;
 
-		default: {
-			if ( codepoint <= 0xFFFF ) {
-				// Exclude surrogate range
-				if ( codepoint < 0xD800 || codepoint > 0xDFFF ) {
-					*output++ = static_cast<wchar_t>( codepoint );
-				} else {
-					// Invalid code point -> replacement
-					if ( replacement ) {
-						*output++ = replacement;
-					}
-				}
-			} else if ( codepoint <= 0x10FFFF ) {
-				// Encode surrogate pair
-				codepoint -= 0x10000;
+		wchar_t high = 0xD800 + ( codepoint >> 10 );
+		wchar_t low = 0xDC00 + ( codepoint & 0x3FF );
 
-				wchar_t high = 0xD800 + ( codepoint >> 10 );
-				wchar_t low = 0xDC00 + ( codepoint & 0x3FF );
-
-				*output++ = high;
-				*output++ = low;
-			} else {
-				// Invalid Unicode range
-				if ( replacement ) {
-					*output++ = replacement;
-				}
-			}
-			break;
+		*output++ = high;
+		*output++ = low;
+	} else {
+		// Invalid Unicode range
+		if ( replacement ) {
+			*output++ = replacement;
 		}
 	}
+
+#else
+	// UTF-32: emit single wchar_t codepoint
+	// Validate code point for UCS-4
+	if ( codepoint <= 0x10FFFF && !( codepoint >= 0xD800 && codepoint <= 0xDFFF ) ) {
+		// Direct copy
+		*output++ = static_cast<wchar_t>( codepoint );
+	} else if ( replacement ) {
+		*output++ = replacement;
+	}
+#endif
 
 	return output;
 }

--- a/src/efsw/Utf.inl
+++ b/src/efsw/Utf.inl
@@ -562,10 +562,28 @@ Out Utf<32>::EncodeWide( Uint32 codepoint, Out output, wchar_t replacement ) {
 		}
 
 		default: {
-			if ( ( codepoint <= 0xFFFF ) && ( ( codepoint < 0xD800 ) || ( codepoint > 0xDFFF ) ) ) {
-				*output++ = static_cast<wchar_t>( codepoint );
-			} else if ( replacement ) {
-				*output++ = replacement;
+			if ( codepoint <= 0xFFFF ) {
+				// Exclude surrogate range
+				if ( codepoint < 0xD800 || codepoint > 0xDFFF ) {
+					*output++ = static_cast<wchar_t>( codepoint );
+				} else {
+					// Invalid code point -> replacement
+					if ( replacement )
+						*output++ = replacement;
+				}
+			} else if ( codepoint <= 0x10FFFF ) {
+				// Encode surrogate pair
+				codepoint -= 0x10000;
+
+				wchar_t high = 0xD800 + ( codepoint >> 10 );
+				wchar_t low = 0xDC00 + ( codepoint & 0x3FF );
+
+				*output++ = high;
+				*output++ = low;
+			} else {
+				// Invalid Unicode range
+				if ( replacement )
+					*output++ = replacement;
 			}
 			break;
 		}

--- a/src/unit_tests/add.cpp
+++ b/src/unit_tests/add.cpp
@@ -1,4 +1,4 @@
-#include "test_util.hpp"
+﻿#include "test_util.hpp"
 #include "utest.h"
 
 using namespace efsw_test;
@@ -20,6 +20,32 @@ UTEST( Add, SingleFile ) {
 	std::string testFile = testDir + "/test_file.txt";
 	EXPECT_TRUE( createFile( testFile, "test content" ) );
 	EXPECT_TRUE( listener.waitForActions( efsw::Actions::Add, "test_file.txt", 3000 ) );
+
+	fileWatcher.removeWatch( testDir );
+	sleepMs( 300 );
+	removeDirectory( testDir );
+}
+
+
+UTEST( Add, SingleFileEmoji ) {
+	std::string testDir = getTemporaryDirectory();
+	EXPECT_TRUE( createDirectory( testDir ) );
+
+	TestListener listener;
+	efsw::FileWatcher fileWatcher( useGeneric, 100 );
+
+	efsw::WatchID watchId = fileWatcher.addWatch( testDir, &listener, true );
+	EXPECT_TRUE( watchId > 0 );
+
+	fileWatcher.watch();
+
+	sleepMs( 500 );
+
+	std::filesystem::path fileName = u8"test_file🐈.txt";
+
+	std::filesystem::path testFile = testDir / fileName;
+	EXPECT_TRUE( createFileFs( testFile, "test content" ) );
+	EXPECT_TRUE( listener.waitForActions( efsw::Actions::Add, fileName.u8string(), 3000 ) );
 
 	fileWatcher.removeWatch( testDir );
 	sleepMs( 300 );

--- a/src/unit_tests/emoji.cpp
+++ b/src/unit_tests/emoji.cpp
@@ -1,0 +1,103 @@
+﻿#include "efsw/String.hpp"
+#include "test_util.hpp"
+#include "utest.h"
+#include <cstdint>
+
+using namespace efsw_test;
+
+#include <iomanip> // std::hex, std::setw, std::setfill
+#include <iostream>
+
+void print_hex_bytes( const std::u32string& s, size_t size ) {
+	for ( int i = 0; i < size; i++) {
+		std::printf( "%08x ", s[i] );
+	}
+	std::cout << "\n";
+}
+
+void print_hex_bytes( const std::string& s ) {
+	for ( unsigned char c : s ) {
+		std::printf( "%02x ", c );
+	}
+	std::cout << "\n";
+}
+
+void print_hex_bytes( const std::wstring& s ) {
+	for ( wchar_t c : s ) {
+		std::printf( "%04x ", c );
+	}
+	std::cout << "\n";
+}
+
+UTEST( Encoding, Utf32String) {
+	const auto emojiString = efsw::String(
+		U"🐈🏳️‍🌈🇺🇸0️⃣✈️™️❤️" );
+
+	const size_t expectedUtf32ByteCount = 16;
+	const char32_t expectedUtf32Bytes[expectedUtf32ByteCount] = {
+		0x0001f408, 0x0001f3f3, 0x0000fe0f, 0x0000200d,
+								 0x0001f308, 0x0001f1fa, 0x0001f1f8, 0x00000030,
+								 0x0000fe0f, 0x000020e3, 0x00002708, 0x0000fe0f,
+								 0x00002122, 0x0000fe0f, 0x00002764, 0x0000fe0f };
+
+	for ( size_t i = 0; i < expectedUtf32ByteCount; ++i ) {
+		EXPECT_EQ( expectedUtf32Bytes[i], emojiString[i] );
+	}
+
+	const auto utf8 = emojiString.toUtf8();
+
+	const size_t expectedUtf8ByteCount = 51;
+	char expectedUtf8Bytes[expectedUtf8ByteCount] = {
+		0xf0, 0x9f, 0x90, 0x88, 0xf0, 0x9f, 0x8f, 0xb3, 0xef, 0xb8, 0x8f,
+							0xe2, 0x80, 0x8d, 0xf0, 0x9f, 0x8c, 0x88, 0xf0, 0x9f, 0x87, 0xba,
+							0xf0, 0x9f, 0x87, 0xb8, 0x30, 0xef, 0xb8, 0x8f, 0xe2, 0x83, 0xa3,
+							0xe2, 0x9c, 0x88, 0xef, 0xb8, 0x8f, 0xe2, 0x84, 0xa2, 0xef, 0xb8,
+							0x8f, 0xe2, 0x9d, 0xa4, 0xef, 0xb8, 0x8f };
+
+	for (size_t i = 0; i < expectedUtf8ByteCount; ++i)
+	{
+		EXPECT_EQ( expectedUtf8Bytes[i], utf8[i] );
+	}
+}
+
+
+UTEST( Encoding, WideString) {
+
+	const auto emojiString = efsw::String(
+		L"🐈🏳️‍🌈🇺🇸0️⃣✈️™️❤️" );
+	
+	const size_t expectedWideByteCount = 21;
+	const char32_t expectedWideBytes[expectedWideByteCount] = {
+		0xd83d, 0xdc08, 0xd83c, 0xdff3, 0xfe0f, 0x200d, 0xd83c, 0xdf08, 0xd83c, 0xddfa, 0xd83c,
+		0xddf8, 0x0030, 0xfe0f, 0x20e3, 0x2708, 0xfe0f, 0x2122, 0xfe0f, 0x2764, 0xfe0f };
+
+	const auto wide = emojiString.toWideString();
+	for ( size_t i = 0; i < expectedWideByteCount; ++i ) {
+		EXPECT_EQ( expectedWideBytes[i], wide[i] );
+	}
+
+	const auto utf8 = emojiString.toUtf8();
+
+	const size_t expectedUtf8ByteCount = 51;
+	char expectedUtf8Bytes[expectedUtf8ByteCount] = {
+		0xf0, 0x9f, 0x90, 0x88, 0xf0, 0x9f, 0x8f, 0xb3, 0xef, 0xb8, 0x8f, 0xe2, 0x80,
+		0x8d, 0xf0, 0x9f, 0x8c, 0x88, 0xf0, 0x9f, 0x87, 0xba, 0xf0, 0x9f, 0x87, 0xb8,
+		0x30, 0xef, 0xb8, 0x8f, 0xe2, 0x83, 0xa3, 0xe2, 0x9c, 0x88, 0xef, 0xb8, 0x8f,
+		0xe2, 0x84, 0xa2, 0xef, 0xb8, 0x8f, 0xe2, 0x9d, 0xa4, 0xef, 0xb8, 0x8f };
+
+	for ( size_t i = 0; i < expectedUtf8ByteCount; ++i ) {
+		EXPECT_EQ( expectedUtf8Bytes[i], utf8[i] );
+	}
+
+	// High surrogate 0xD83D followed by 'A'instead of a low surrogate should be rejected
+	const wchar_t replacement = L'\uFFFD';
+	auto invalidPair = efsw::String( L"\xD83D\x0041" );
+	EXPECT_EQ( invalidPair.data()[0], replacement );
+	EXPECT_EQ( invalidPair.data()[1], L'\u0041' );
+
+
+	// Test that single-character surrugate pairs are rejected
+	const auto rejectedString = efsw::String( static_cast<wchar_t>( 0xDA00u ) );
+
+	EXPECT_EQ( rejectedString.data()[0], replacement );
+}

--- a/src/unit_tests/emoji.cpp
+++ b/src/unit_tests/emoji.cpp
@@ -48,9 +48,9 @@ UTEST( Encoding, WideString ) {
 	// Linux/macOS / UTF-32
 	const size_t expectedWideByteCount = 16;
 	const wchar_t expectedWideBytes[expectedWideByteCount] = {
-		0x0001F408, 0x0001F3F3, 0x0000FE0F, 0x0000200D, 0x0001F308, 0x0001F1FA,
-		0x0001F1F8, 0x00000030, 0x0000FE0F, 0x000020E3, 0x00002708, 0x0000FE0F,
-		0x00002122, 0x0000FE0F, 0x00002764, 0x0000FE0F };
+		0x0001f408, 0x0001f3f3, 0x0000fe0f, 0x0000200d, 0x0001f308, 0x0001f1fa,
+		0x0001f1f8, 0x00000030, 0x0000fe0f, 0x000020e3, 0x00002708, 0x0000fe0f,
+		0x00002122, 0x0000fe0f, 0x00002764, 0x0000fe0f };
 #endif
 
 	const auto expectedWideString = std::wstring( expectedWideBytes, expectedWideByteCount );

--- a/src/unit_tests/emoji.cpp
+++ b/src/unit_tests/emoji.cpp
@@ -94,7 +94,6 @@ should return the replacement character (as the emoji does not fit into wchar_t)
 platforms it should work
 */
 UTEST( Encoding, WideCharEmoji ) {
-	[[maybe_unused]] const uint32_t replacement = 0xFFFDu;
 
 #if WCHAR_MAX == 0xFFFF
 	// Windows: 16‑bit wchar_t, use first surrogate of U+1F408
@@ -109,6 +108,7 @@ UTEST( Encoding, WideCharEmoji ) {
 
 #if WCHAR_MAX == 0xFFFF
 	// On Windows we expect the replacement character
+	const uint32_t replacement = 0xFFFDu;
 	EXPECT_EQ( code, replacement );
 #else
 	// On other platforms we expect the actual cat emoji code point

--- a/src/unit_tests/emoji.cpp
+++ b/src/unit_tests/emoji.cpp
@@ -70,7 +70,7 @@ UTEST( Encoding, WideString ) {
 	const auto expectedUtf8String =
 		std::string( reinterpret_cast<const char*>( expectedUtf8Bytes ), expectedUtf8ByteCount );
 
-	EXPECT_EQ( expectedUtf8String, utf8 );
+	EXPECT_TRUE( expectedUtf8String == utf8 );
 
 	// High surrogate 0xD83D followed by 'A'instead of a low surrogate should be rejected.
 	// DecodeWide does validation for both UTF-16 and UTF-32 machines, otherwise this test would
@@ -94,7 +94,7 @@ should return the replacement character (as the emoji does not fit into wchar_t)
 platforms it should work
 */
 UTEST( Encoding, WideCharEmoji ) {
-	const uint32_t replacement = 0xFFFDu;
+	[[maybe_unused]] const uint32_t replacement = 0xFFFDu;
 
 #if WCHAR_MAX == 0xFFFF
 	// Windows: 16‑bit wchar_t, use first surrogate of U+1F408

--- a/src/unit_tests/emoji.cpp
+++ b/src/unit_tests/emoji.cpp
@@ -1,6 +1,7 @@
 ﻿#include "efsw/String.hpp"
 #include "test_util.hpp"
 #include "utest.h"
+
 #include <cstdint>
 
 using namespace efsw_test;
@@ -15,7 +16,7 @@ UTEST( Encoding, Utf32String ) {
 		0x0001f1f8, 0x00000030, 0x0000fe0f, 0x000020e3, 0x00002708, 0x0000fe0f,
 		0x00002122, 0x0000fe0f, 0x00002764, 0x0000fe0f };
 	const auto expectedUtf32String = std::u32string( expectedUtf32Bytes, expectedUtf32ByteCount );
-	EXPECT_EQ( expectedUtf32String, emojiString );
+	EXPECT_TRUE( expectedUtf32String == emojiString );
 
 	// Test utf32 -> utf8
 	const auto utf8 = emojiString.toUtf8();
@@ -29,7 +30,7 @@ UTEST( Encoding, Utf32String ) {
 	const auto expectedUtf8String =
 		std::string( reinterpret_cast<const char*>( expectedUtf8Bytes ), expectedUtf8ByteCount );
 
-	EXPECT_EQ( expectedUtf8String, utf8 );
+	EXPECT_TRUE( expectedUtf8String == utf8 );
 }
 
 UTEST( Encoding, WideString ) {
@@ -37,14 +38,25 @@ UTEST( Encoding, WideString ) {
 	const auto emojiString = efsw::String( L"🐈🏳️‍🌈🇺🇸0️⃣✈️™️❤️" );
 
 	// Test wide -> utf32
+#if WCHAR_MAX == 0xFFFF
+	// Windows / UTF-16
 	const size_t expectedWideByteCount = 21;
 	const wchar_t expectedWideBytes[expectedWideByteCount] = {
 		0xd83d, 0xdc08, 0xd83c, 0xdff3, 0xfe0f, 0x200d, 0xd83c, 0xdf08, 0xd83c, 0xddfa, 0xd83c,
 		0xddf8, 0x0030, 0xfe0f, 0x20e3, 0x2708, 0xfe0f, 0x2122, 0xfe0f, 0x2764, 0xfe0f };
+#else
+	// Linux/macOS / UTF-32
+	const size_t expectedWideByteCount = 16;
+	const wchar_t expectedWideBytes[expectedWideByteCount] = {
+		0x0001F408, 0x0001F3F3, 0x0000FE0F, 0x0000200D, 0x0001F308, 0x0001F1FA,
+		0x0001F1F8, 0x00000030, 0x0000FE0F, 0x000020E3, 0x00002708, 0x0000FE0F,
+		0x00002122, 0x0000FE0F, 0x00002764, 0x0000FE0F };
+#endif
+
 	const auto expectedWideString = std::wstring( expectedWideBytes, expectedWideByteCount );
 
 	const auto wide = emojiString.toWideString();
-	EXPECT_EQ( expectedWideString, wide );
+	EXPECT_TRUE( expectedWideString == wide );
 
 	// Test utf32 -> utf8
 	const auto utf8 = emojiString.toUtf8();
@@ -60,14 +72,46 @@ UTEST( Encoding, WideString ) {
 
 	EXPECT_EQ( expectedUtf8String, utf8 );
 
-	// High surrogate 0xD83D followed by 'A'instead of a low surrogate should be rejected
+	// High surrogate 0xD83D followed by 'A'instead of a low surrogate should be rejected.
+	// DecodeWide does validation for both UTF-16 and UTF-32 machines, otherwise this test would
+	// need to have different cases for each platform
 	const wchar_t replacement = L'\uFFFD';
 	auto invalidPair = efsw::String( L"\xD83D\x0041" );
-	EXPECT_EQ( invalidPair.data()[0], replacement );
-	EXPECT_EQ( invalidPair.data()[1], L'\u0041' );
+	EXPECT_EQ( static_cast<uint32_t>( invalidPair.data()[0] ),
+			   static_cast<uint32_t>( replacement ) );
+	EXPECT_EQ( static_cast<uint32_t>( invalidPair.data()[1] ), static_cast<uint32_t>( L'\u0041' ) );
 
-	// Test that single-character surrugate pairs are rejected
+	// Test that single-character surrogate pairs are rejected
 	const auto rejectedString = efsw::String( static_cast<wchar_t>( 0xDA00u ) );
 
-	EXPECT_EQ( rejectedString.data()[0], replacement );
+	EXPECT_EQ( static_cast<uint32_t>( rejectedString.data()[0] ),
+			   static_cast<uint32_t>( replacement ) );
+}
+
+/*
+Constructs efsw::String with the a cat emoji using the wchar_t constructor. On UTF-16 platforms it
+should return the replacement character (as the emoji does not fit into wchar_t), and on other
+platforms it should work
+*/
+UTEST( Encoding, WideCharEmoji ) {
+	const uint32_t replacement = 0xFFFDu;
+
+#if WCHAR_MAX == 0xFFFF
+	// Windows: 16‑bit wchar_t, use first surrogate of U+1F408
+	const wchar_t cat = static_cast<wchar_t>( 0xD83Du );
+#else
+	// Linux/macOS: 32‑bit wchar_t, full code point fits in one wchar_t
+	const wchar_t cat = L'🐈';
+#endif
+
+	const auto s = efsw::String( cat );
+	const auto code = static_cast<uint32_t>( s.data()[0] );
+
+#if WCHAR_MAX == 0xFFFF
+	// On Windows we expect the replacement character
+	EXPECT_EQ( code, replacement );
+#else
+	// On other platforms we expect the actual cat emoji code point
+	EXPECT_EQ( code, static_cast<uint32_t>( L'🐈' ) );
+#endif
 }

--- a/src/unit_tests/emoji.cpp
+++ b/src/unit_tests/emoji.cpp
@@ -5,30 +5,6 @@
 
 using namespace efsw_test;
 
-#include <iomanip> // std::hex, std::setw, std::setfill
-#include <iostream>
-
-void print_hex_bytes( const std::u32string& s, size_t size ) {
-	for ( int i = 0; i < size; i++) {
-		std::printf( "%08x ", s[i] );
-	}
-	std::cout << "\n";
-}
-
-void print_hex_bytes( const std::string& s ) {
-	for ( unsigned char c : s ) {
-		std::printf( "%02x ", c );
-	}
-	std::cout << "\n";
-}
-
-void print_hex_bytes( const std::wstring& s ) {
-	for ( wchar_t c : s ) {
-		std::printf( "%04x ", c );
-	}
-	std::cout << "\n";
-}
-
 UTEST( Encoding, Utf32String) {
 	const auto emojiString = efsw::String(
 		U"🐈🏳️‍🌈🇺🇸0️⃣✈️™️❤️" );

--- a/src/unit_tests/emoji.cpp
+++ b/src/unit_tests/emoji.cpp
@@ -5,72 +5,66 @@
 
 using namespace efsw_test;
 
-UTEST( Encoding, Utf32String) {
-	const auto emojiString = efsw::String(
-		U"🐈🏳️‍🌈🇺🇸0️⃣✈️™️❤️" );
+UTEST( Encoding, Utf32String ) {
+	const auto emojiString = efsw::String( U"🐈🏳️‍🌈🇺🇸0️⃣✈️™️❤️" );
 
+	// Test utf32 -> utf32
 	const size_t expectedUtf32ByteCount = 16;
 	const char32_t expectedUtf32Bytes[expectedUtf32ByteCount] = {
-		0x0001f408, 0x0001f3f3, 0x0000fe0f, 0x0000200d,
-								 0x0001f308, 0x0001f1fa, 0x0001f1f8, 0x00000030,
-								 0x0000fe0f, 0x000020e3, 0x00002708, 0x0000fe0f,
-								 0x00002122, 0x0000fe0f, 0x00002764, 0x0000fe0f };
+		0x0001f408, 0x0001f3f3, 0x0000fe0f, 0x0000200d, 0x0001f308, 0x0001f1fa,
+		0x0001f1f8, 0x00000030, 0x0000fe0f, 0x000020e3, 0x00002708, 0x0000fe0f,
+		0x00002122, 0x0000fe0f, 0x00002764, 0x0000fe0f };
+	const auto expectedUtf32String = std::u32string( expectedUtf32Bytes, expectedUtf32ByteCount );
+	EXPECT_EQ( expectedUtf32String, emojiString );
 
-	for ( size_t i = 0; i < expectedUtf32ByteCount; ++i ) {
-		EXPECT_EQ( expectedUtf32Bytes[i], emojiString[i] );
-	}
-
+	// Test utf32 -> utf8
 	const auto utf8 = emojiString.toUtf8();
 
 	const size_t expectedUtf8ByteCount = 51;
-	char expectedUtf8Bytes[expectedUtf8ByteCount] = {
-		0xf0, 0x9f, 0x90, 0x88, 0xf0, 0x9f, 0x8f, 0xb3, 0xef, 0xb8, 0x8f,
-							0xe2, 0x80, 0x8d, 0xf0, 0x9f, 0x8c, 0x88, 0xf0, 0x9f, 0x87, 0xba,
-							0xf0, 0x9f, 0x87, 0xb8, 0x30, 0xef, 0xb8, 0x8f, 0xe2, 0x83, 0xa3,
-							0xe2, 0x9c, 0x88, 0xef, 0xb8, 0x8f, 0xe2, 0x84, 0xa2, 0xef, 0xb8,
-							0x8f, 0xe2, 0x9d, 0xa4, 0xef, 0xb8, 0x8f };
-
-	for (size_t i = 0; i < expectedUtf8ByteCount; ++i)
-	{
-		EXPECT_EQ( expectedUtf8Bytes[i], utf8[i] );
-	}
-}
-
-
-UTEST( Encoding, WideString) {
-
-	const auto emojiString = efsw::String(
-		L"🐈🏳️‍🌈🇺🇸0️⃣✈️™️❤️" );
-	
-	const size_t expectedWideByteCount = 21;
-	const char32_t expectedWideBytes[expectedWideByteCount] = {
-		0xd83d, 0xdc08, 0xd83c, 0xdff3, 0xfe0f, 0x200d, 0xd83c, 0xdf08, 0xd83c, 0xddfa, 0xd83c,
-		0xddf8, 0x0030, 0xfe0f, 0x20e3, 0x2708, 0xfe0f, 0x2122, 0xfe0f, 0x2764, 0xfe0f };
-
-	const auto wide = emojiString.toWideString();
-	for ( size_t i = 0; i < expectedWideByteCount; ++i ) {
-		EXPECT_EQ( expectedWideBytes[i], wide[i] );
-	}
-
-	const auto utf8 = emojiString.toUtf8();
-
-	const size_t expectedUtf8ByteCount = 51;
-	char expectedUtf8Bytes[expectedUtf8ByteCount] = {
+	unsigned char expectedUtf8Bytes[expectedUtf8ByteCount] = {
 		0xf0, 0x9f, 0x90, 0x88, 0xf0, 0x9f, 0x8f, 0xb3, 0xef, 0xb8, 0x8f, 0xe2, 0x80,
 		0x8d, 0xf0, 0x9f, 0x8c, 0x88, 0xf0, 0x9f, 0x87, 0xba, 0xf0, 0x9f, 0x87, 0xb8,
 		0x30, 0xef, 0xb8, 0x8f, 0xe2, 0x83, 0xa3, 0xe2, 0x9c, 0x88, 0xef, 0xb8, 0x8f,
 		0xe2, 0x84, 0xa2, 0xef, 0xb8, 0x8f, 0xe2, 0x9d, 0xa4, 0xef, 0xb8, 0x8f };
+	const auto expectedUtf8String =
+		std::string( reinterpret_cast<const char*>( expectedUtf8Bytes ), expectedUtf8ByteCount );
 
-	for ( size_t i = 0; i < expectedUtf8ByteCount; ++i ) {
-		EXPECT_EQ( expectedUtf8Bytes[i], utf8[i] );
-	}
+	EXPECT_EQ( expectedUtf8String, utf8 );
+}
+
+UTEST( Encoding, WideString ) {
+
+	const auto emojiString = efsw::String( L"🐈🏳️‍🌈🇺🇸0️⃣✈️™️❤️" );
+
+	// Test wide -> utf32
+	const size_t expectedWideByteCount = 21;
+	const wchar_t expectedWideBytes[expectedWideByteCount] = {
+		0xd83d, 0xdc08, 0xd83c, 0xdff3, 0xfe0f, 0x200d, 0xd83c, 0xdf08, 0xd83c, 0xddfa, 0xd83c,
+		0xddf8, 0x0030, 0xfe0f, 0x20e3, 0x2708, 0xfe0f, 0x2122, 0xfe0f, 0x2764, 0xfe0f };
+	const auto expectedWideString = std::wstring( expectedWideBytes, expectedWideByteCount );
+
+	const auto wide = emojiString.toWideString();
+	EXPECT_EQ( expectedWideString, wide );
+
+	// Test utf32 -> utf8
+	const auto utf8 = emojiString.toUtf8();
+
+	const size_t expectedUtf8ByteCount = 51;
+	unsigned char expectedUtf8Bytes[expectedUtf8ByteCount] = {
+		0xf0, 0x9f, 0x90, 0x88, 0xf0, 0x9f, 0x8f, 0xb3, 0xef, 0xb8, 0x8f, 0xe2, 0x80,
+		0x8d, 0xf0, 0x9f, 0x8c, 0x88, 0xf0, 0x9f, 0x87, 0xba, 0xf0, 0x9f, 0x87, 0xb8,
+		0x30, 0xef, 0xb8, 0x8f, 0xe2, 0x83, 0xa3, 0xe2, 0x9c, 0x88, 0xef, 0xb8, 0x8f,
+		0xe2, 0x84, 0xa2, 0xef, 0xb8, 0x8f, 0xe2, 0x9d, 0xa4, 0xef, 0xb8, 0x8f };
+	const auto expectedUtf8String =
+		std::string( reinterpret_cast<const char*>( expectedUtf8Bytes ), expectedUtf8ByteCount );
+
+	EXPECT_EQ( expectedUtf8String, utf8 );
 
 	// High surrogate 0xD83D followed by 'A'instead of a low surrogate should be rejected
 	const wchar_t replacement = L'\uFFFD';
 	auto invalidPair = efsw::String( L"\xD83D\x0041" );
 	EXPECT_EQ( invalidPair.data()[0], replacement );
 	EXPECT_EQ( invalidPair.data()[1], L'\u0041' );
-
 
 	// Test that single-character surrugate pairs are rejected
 	const auto rejectedString = efsw::String( static_cast<wchar_t>( 0xDA00u ) );

--- a/src/unit_tests/test_util.hpp
+++ b/src/unit_tests/test_util.hpp
@@ -104,6 +104,17 @@ inline bool createFile( const std::string& path, const std::string& content = ""
 	return true;
 }
 
+inline bool createFileFs( const std::filesystem::path& path, const std::string& content = "" ) {
+	std::ofstream f( path );
+	if ( !f )
+		return false;
+	if ( !content.empty() ) {
+		f << content;
+	}
+	f.close();
+	return true;
+}
+
 inline bool removeFile( const std::string& path ) {
 	std::error_code ec;
 	std::filesystem::remove( path, ec );


### PR DESCRIPTION
Efsw failes to generate events for filepaths with emojis in them and produces corrupt paths. This is caused by:
* Wide strings were not encoded and decoded to/from UTF-32 properly on machines where a wide char is 16 bits, causing emojis and surrogate pairs to get corrupted

Fixed by:
*  Treating 16‑bit wchar_t as UTF‑16 and correctly decoding surrogate pairs into UTF‑32  values in DecodeWide/FromWide
* Validating and rejecting invalid surrogate sequences (mapping them to U+FFFD) and validating 32‑bit wchar_t as UTF‑32
* Added test cases verifying text encoding aswell as file events being received