### PR TITLE
Set SOVERSION for shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.27 FATAL_ERROR)
 
-project(efsw)
+project(efsw VERSION 1.6.3)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 if (NOT CMAKE_CXX_STANDARD)
@@ -71,6 +71,10 @@ target_compile_features(efsw PRIVATE cxx_std_11)
 
 if(BUILD_SHARED_LIBS)
 	target_compile_definitions(efsw PRIVATE EFSW_DYNAMIC EFSW_EXPORTS)
+	set_target_properties(efsw PROPERTIES
+		VERSION ${CMAKE_PROJECT_VERSION}
+		SOVERSION 1
+	)
 endif()
 
 # platforms


### PR DESCRIPTION
Sets `VERSION` and `SOVERSION` for shared library ([doc](https://cmake.org/cmake/help/latest/prop_tgt/SOVERSION.html)). This ensures proper symlinks on Linux systems.

`SOVERSION` is the library's ABI major version, and should be changed on ABI breaking changes.