### PR TITLE
Set shared lib versioning based on the project version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,8 @@ target_compile_features(efsw PRIVATE cxx_std_11)
 if(BUILD_SHARED_LIBS)
 	target_compile_definitions(efsw PRIVATE EFSW_DYNAMIC EFSW_EXPORTS)
 	set_target_properties(efsw PROPERTIES
-		VERSION ${CMAKE_PROJECT_VERSION}
-		SOVERSION 1
+		VERSION ${PROJECT_VERSION}
+		SOVERSION ${PROJECT_VERSION_MAJOR}
 	)
 endif()
 


### PR DESCRIPTION
This PR will fix 2 issues:
- The first issue is the use of `CMAKE_PRJECT_VERSION`, the value is set only at the top level `CMakeLists.txt`. This project nicely handles the case where its added as a subproject but that would leave the variable as defined in the top level file, see [docs](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_VERSION.html). This will cause the version of the shared lib to not be the expected value, while the use of `PROJECT_VERSION` always gets the version of the most recent call to `project` and thus will also properly work if included as a subproject.
- The second issue is that the `SOVERSION` could get out of sync with what is defined in the `project` call at the top of the CMake file. By using `PROJECT_VERSION_MAJOR` it will use the major version part of the version defined in the project. It does not use the `CMAKE_PROJECT_VERSION_MAJOR` as that has the same issues as above.