### PR TITLE
Add CMake version configuration for find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,8 +188,8 @@ if(EFSW_INSTALL)
 	install(EXPORT efswExport NAMESPACE efsw:: DESTINATION "${packageDestDir}" FILE ${PROJECT_NAME}Targets.cmake)
 	install(FILES
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/efswConfig.cmake
-	    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
-	  DESTINATION "${packageDestDir}"
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
+    DESTINATION "${packageDestDir}"
 	)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,11 +186,11 @@ if(EFSW_INSTALL)
 	endif()
 
 	install(EXPORT efswExport NAMESPACE efsw:: DESTINATION "${packageDestDir}" FILE ${PROJECT_NAME}Targets.cmake)
-	install(FILES
+  install(FILES
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/efswConfig.cmake
       ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
     DESTINATION "${packageDestDir}"
-	)
+  )
 endif()
 
 if(BUILD_TEST_APP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,11 +186,11 @@ if(EFSW_INSTALL)
 	endif()
 
 	install(EXPORT efswExport NAMESPACE efsw:: DESTINATION "${packageDestDir}" FILE ${PROJECT_NAME}Targets.cmake)
-  install(FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/cmake/efswConfig.cmake
-      ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
-    DESTINATION "${packageDestDir}"
-  )
+	install(FILES
+			${CMAKE_CURRENT_BINARY_DIR}/cmake/efswConfig.cmake
+			${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
+		DESTINATION "${packageDestDir}"
+	)
 endif()
 
 if(BUILD_TEST_APP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,12 @@ configure_package_config_file(
 	NO_CHECK_REQUIRED_COMPONENTS_MACRO
 )
 
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
+  VERSION       ${PROJECT_VERSION}
+  COMPATIBILITY SameMajorVersion
+)
+
 export(TARGETS efsw NAMESPACE efsw:: FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake)
 if(BUILD_STATIC_LIBS)
 	export(TARGETS efsw-static NAMESPACE efsw:: APPEND FILE ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}Targets.cmake)
@@ -180,7 +186,11 @@ if(EFSW_INSTALL)
 	endif()
 
 	install(EXPORT efswExport NAMESPACE efsw:: DESTINATION "${packageDestDir}" FILE ${PROJECT_NAME}Targets.cmake)
-	install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/efswConfig.cmake DESTINATION "${packageDestDir}")
+	install(FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/cmake/efswConfig.cmake
+	    ${CMAKE_CURRENT_BINARY_DIR}/cmake/${PROJECT_NAME}ConfigVersion.cmake
+	  DESTINATION "${packageDestDir}"
+	)
 endif()
 
 if(BUILD_TEST_APP)


### PR DESCRIPTION
This PR adds a package version file for CMake. I added this so consumers that use this library with a `find_package` can specify a version in the `find_package` and CMake will check if a [compatible version is installed](https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-version-selection).

This way consumers can be specific on which version they would like, if they are both installed. I set the compatibility to the `SameMajorVersion` so that when a breaking change is introduced it will not accidentally break all consumers but instead will error on a CMake configure level. 