### PR TITLE
Correlate moves from different dirs for linux

### DIFF
--- a/include/efsw/efsw.h
+++ b/include/efsw/efsw.h
@@ -118,6 +118,16 @@ enum efsw_option {
 	/// files in the new directory watched. This might have the unintended consequence of sending
 	/// duplicated created events due to the system also emitting this event.
 	EFSW_LINUX_PRODUCE_SYNTHETIC_EVENTS = 5,
+	/// Linux does not support cross directory moves. This means that when a file is moved from
+	/// one directory to another the system will emit a delete event for the source directory and
+	/// a create event for the destination directory. Enabling this option will make efsw attempt
+	/// to detect such moves and report them as a single Moved event, with oldFilename set to the
+	/// source path as an absolute path (e.g. "/home/user/tmp/upload.tmp").
+	/// NOTE: Both source and destination must be inside the same watched tree (single recursive
+	/// watch, or two watches on the same FileWatcher instance). If the source directory is not
+	/// watched, inotify will not emit IN_MOVED_FROM and efsw falls back to Add+Modified.
+	/// This option is Linux-specific and depends on inotify rename cookies.
+	EFSW_OPT_LINUX_REPORT_CROSS_DIRECTORY_MOVES = 6,
 };
 
 /// Basic interface for listening for file events.

--- a/include/efsw/efsw.hpp
+++ b/include/efsw/efsw.hpp
@@ -164,10 +164,11 @@ enum Option {
 	/// one directory to another the system will emit a delete event for the source directory and
 	/// a create event for the destination directory. Enabling this option will make efsw attempt
 	/// to detect such moves and report them as a single Moved event, with oldFilename set to the
-	/// source path relative to the watched root (e.g. "tmp/upload.tmp").
+	/// source path as an absolute path (e.g. "/home/user/tmp/upload.tmp").
 	/// NOTE: Both source and destination must be inside the same watched tree (single recursive
 	/// watch, or two watches on the same FileWatcher instance). If the source directory is not
 	/// watched, inotify will not emit IN_MOVED_FROM and efsw falls back to Add+Modified.
+	/// This option is Linux-specific and depends on inotify rename cookies.
 	LinuxReportCrossDirectoryMoves = 6,
 };
 }

--- a/include/efsw/efsw.hpp
+++ b/include/efsw/efsw.hpp
@@ -160,6 +160,15 @@ enum Option {
 	/// files in the new directory watched. This might have the unintended consequence of sending
 	/// duplicated created events due to the system also emitting this event.
 	LinuxProduceSyntheticEvents = 5,
+	/// Linux does not support cross directory moves. This means that when a file is moved from
+	/// one directory to another the system will emit a delete event for the source directory and
+	/// a create event for the destination directory. Enabling this option will make efsw attempt
+	/// to detect such moves and report them as a single Moved event, with oldFilename set to the
+	/// source path relative to the watched root (e.g. "tmp/upload.tmp").
+	/// NOTE: Both source and destination must be inside the same watched tree (single recursive
+	/// watch, or two watches on the same FileWatcher instance). If the source directory is not
+	/// watched, inotify will not emit IN_MOVED_FROM and efsw falls back to Add+Modified.
+	LinuxReportCrossDirectoryMoves = 6,
 };
 }
 typedef Options::Option Option;

--- a/src/efsw/FileWatcherInotify.cpp
+++ b/src/efsw/FileWatcherInotify.cpp
@@ -74,6 +74,9 @@ WatchID FileWatcherInotify::addWatch( const std::string& directory, FileWatchLis
 	if ( !mInitOK )
 		return Errors::Log::createLastError( Errors::Unspecified, directory );
 	Lock initLock( mInitLock );
+
+	this->mReportCrossDirectoryMoves = getOptionValue( options, Options::LinuxReportCrossDirectoryMoves, 0 ) != 0;
+
 	bool syntheticEvents = getOptionValue( options, Options::LinuxProduceSyntheticEvents, 0 ) != 0;
 	return addWatch( directory, watcher, recursive, syntheticEvents, NULL );
 }
@@ -346,10 +349,15 @@ void FileWatcherInotify::run() {
 
 								// If the move happened between TWO DIFFERENT watched directories
 								if ( curWatcher != currentMoveFrom ) {
-									// We need to simulate a delete event, the IN_MOVED_TO will
-									// generate an add event after
-									handleAction( currentMoveFrom, currentMoveFrom->OldFileName,
-												  IN_DELETE );
+									if ( mReportCrossDirectoryMoves ) {
+										handleAction( currentMoveFrom, currentMoveFrom->OldFileName,
+													  IN_MOVED_TO );
+									} else {
+										// We need to simulate a delete event, the IN_MOVED_TO will
+										// generate an add event after
+										handleAction( currentMoveFrom, currentMoveFrom->OldFileName,
+													  IN_DELETE );
+									}
 
 									// Clear the state on the source watcher so it doesn't
 									// get processed again or stuck with stale data.

--- a/src/efsw/FileWatcherInotify.cpp
+++ b/src/efsw/FileWatcherInotify.cpp
@@ -75,7 +75,8 @@ WatchID FileWatcherInotify::addWatch( const std::string& directory, FileWatchLis
 		return Errors::Log::createLastError( Errors::Unspecified, directory );
 	Lock initLock( mInitLock );
 
-	this->mReportCrossDirectoryMoves = getOptionValue( options, Options::LinuxReportCrossDirectoryMoves, 0 ) != 0;
+	mReportCrossDirectoryMoves =
+		getOptionValue( options, Options::LinuxReportCrossDirectoryMoves, 0 ) != 0;
 
 	bool syntheticEvents = getOptionValue( options, Options::LinuxProduceSyntheticEvents, 0 ) != 0;
 	return addWatch( directory, watcher, recursive, syntheticEvents, NULL );
@@ -341,17 +342,27 @@ void FileWatcherInotify::run() {
 						}
 
 						if ( curWatcher ) {
-							handleAction( curWatcher, (char*)pevent->name, pevent->mask );
+							// For IN_MOVED_TO: if we have a pending cross-dir move with the
+							// option enabled, defer the event — we'll emit Moved instead of
+							// the default Add+Modified that handleAction would fire.
+							bool isMoveActionDst = ( pevent->mask & IN_MOVED_TO ) &&
+												   currentMoveFrom &&
+												   pevent->cookie == currentMoveCookie;
+							bool moveBetweenTwoWatchedDirs =
+								isMoveActionDst && curWatcher != currentMoveFrom;
+							bool deferredMovedTo =
+								moveBetweenTwoWatchedDirs && mReportCrossDirectoryMoves;
+
+							if ( !deferredMovedTo )
+								handleAction( curWatcher, (char*)pevent->name, pevent->mask );
 
 							// Check if this is the destination of a move
-							if ( ( pevent->mask & IN_MOVED_TO ) && currentMoveFrom &&
-								 pevent->cookie == currentMoveCookie ) {
-
-								// If the move happened between TWO DIFFERENT watched directories
-								if ( curWatcher != currentMoveFrom ) {
-									if ( mReportCrossDirectoryMoves ) {
-										handleAction( currentMoveFrom, currentMoveFrom->OldFileName,
-													  IN_MOVED_TO );
+							if ( isMoveActionDst ) {
+								if ( moveBetweenTwoWatchedDirs ) {
+									if ( deferredMovedTo ) {
+										emitCrossDirectoryMove(
+											currentMoveFrom, currentMoveFrom->OldFileName,
+											curWatcher, std::string( (char*)pevent->name ) );
 									} else {
 										// We need to simulate a delete event, the IN_MOVED_TO will
 										// generate an add event after
@@ -568,6 +579,18 @@ void FileWatcherInotify::checkForNewWatcher( Watcher* watch, std::string fpath )
 					  static_cast<WatcherInotify*>( watch ), true );
 		}
 	}
+}
+
+void FileWatcherInotify::emitCrossDirectoryMove( Watcher* src, const std::string& srcFile,
+												 Watcher* dst, const std::string& dstFile ) {
+	if ( !src || !dst ) {
+		return;
+	}
+
+	std::string oldDstFilename = dst->OldFileName;
+	dst->OldFileName = src->Directory + srcFile;
+	handleAction( dst, dstFile, IN_MOVED_TO );
+	dst->OldFileName = std::move( oldDstFilename );
 }
 
 void FileWatcherInotify::handleAction( Watcher* watch, const std::string& filename,

--- a/src/efsw/FileWatcherInotify.hpp
+++ b/src/efsw/FileWatcherInotify.hpp
@@ -71,9 +71,12 @@ class FileWatcherInotify : public FileWatcherImpl {
 	bool pathInWatches( const std::string& path ) override;
 
   private:
-	bool mReportCrossDirectoryMoves {false};
+	bool mReportCrossDirectoryMoves{ false };
 
 	void run();
+
+	void emitCrossDirectoryMove( Watcher* src, const std::string& srcFile, Watcher* dst,
+								 const std::string& dstFile );
 
 	void removeWatchLocked( WatchID watchid, bool skipInotifyRemove = false );
 

--- a/src/efsw/FileWatcherInotify.hpp
+++ b/src/efsw/FileWatcherInotify.hpp
@@ -71,6 +71,8 @@ class FileWatcherInotify : public FileWatcherImpl {
 	bool pathInWatches( const std::string& path ) override;
 
   private:
+	bool mReportCrossDirectoryMoves {false};
+
 	void run();
 
 	void removeWatchLocked( WatchID watchid, bool skipInotifyRemove = false );

--- a/src/unit_tests/cross_dir_and_watcher.cpp
+++ b/src/unit_tests/cross_dir_and_watcher.cpp
@@ -173,3 +173,79 @@ UTEST( MoveFolderCrossDir, FolderBetweenTwoWatchedDirs ) {
 	removeDirectory( watchedDir1 );
 	removeDirectory( watchedDir2 );
 }
+
+#ifdef __linux__
+// With LinuxReportCrossDirectoryMoves enabled, a rename across subdirectories of a single
+// recursive watch should produce exactly one Moved event (no Delete, no Add).
+UTEST( CrossDirMove, ReportsMovedEventWithOptionRecursive ) {
+	std::string rootDir = getTemporaryDirectory();
+	std::string tmpDir = rootDir + "/tmp";
+	std::string dataDir = rootDir + "/data";
+
+	EXPECT_TRUE( createDirectory( rootDir ) );
+	EXPECT_TRUE( createDirectory( tmpDir ) );
+	EXPECT_TRUE( createDirectory( dataDir ) );
+
+	std::string srcFile = tmpDir + "/upload.tmp";
+	EXPECT_TRUE( createFile( srcFile, "content" ) );
+
+	TestListener listener;
+	efsw::FileWatcher fileWatcher( useGeneric, 100 );
+
+	std::vector<efsw::WatcherOption> options = {
+		{ efsw::Options::LinuxReportCrossDirectoryMoves, 1 } };
+	efsw::WatchID watchId = fileWatcher.addWatch( rootDir, &listener, true, options );
+	EXPECT_TRUE( watchId > 0 );
+
+	fileWatcher.watch();
+	sleepMs( 200 );
+	listener.clearEvents();
+
+	std::string dstFile = dataDir + "/config.json";
+	EXPECT_TRUE( renameFile( srcFile, dstFile ) );
+
+	// Expect a single Moved event for the destination filename
+	EXPECT_TRUE( listener.waitForActions( efsw::Actions::Moved, "config.json" ) );
+
+	// There must be no Delete or Add events for these filenames
+	EXPECT_FALSE( listener.checkEvent( efsw::Actions::Delete, "upload.tmp" ) );
+	EXPECT_FALSE( listener.checkEvent( efsw::Actions::Add, "config.json" ) );
+
+	fileWatcher.removeWatch( rootDir );
+	removeDirectory( rootDir );
+}
+#endif //__linux__
+
+// Without the option, cross-dir moves across a recursive watch still produce Delete+Add.
+UTEST( CrossDirMove, FallsBackToDeleteAddWithoutOption ) {
+	std::string rootDir = getTemporaryDirectory();
+	std::string tmpDir = rootDir + "/tmp";
+	std::string dataDir = rootDir + "/data";
+
+	EXPECT_TRUE( createDirectory( rootDir ) );
+	EXPECT_TRUE( createDirectory( tmpDir ) );
+	EXPECT_TRUE( createDirectory( dataDir ) );
+
+	std::string srcFile = tmpDir + "/upload.tmp";
+	EXPECT_TRUE( createFile( srcFile, "content" ) );
+
+	TestListener listener;
+	efsw::FileWatcher fileWatcher( useGeneric, 100 );
+
+	efsw::WatchID watchId = fileWatcher.addWatch( rootDir, &listener, true );
+	EXPECT_TRUE( watchId > 0 );
+
+	fileWatcher.watch();
+	sleepMs( 200 );
+	listener.clearEvents();
+
+	std::string dstFile = dataDir + "/config.json";
+	EXPECT_TRUE( renameFile( srcFile, dstFile ) );
+
+	EXPECT_TRUE( listener.waitForActions( efsw::Actions::Delete, "upload.tmp" ) );
+	EXPECT_TRUE( listener.waitForActions( efsw::Actions::Add, "config.json" ) );
+	EXPECT_FALSE( listener.checkEvent( efsw::Actions::Moved, "config.json" ) );
+
+	fileWatcher.removeWatch( rootDir );
+	removeDirectory( rootDir );
+}


### PR DESCRIPTION
**Summary**
This PR improves how file moves are reported when a file is moved within a subdirectory. Instead of surfacing the change as a `delete` in the original location plus an `add` and `modified` in the new location, the move is now detected and represented as a single move operation.

_Old behavior:_
- `DIR (oldDir) FILE (oldFilename) has event Delete`
- `DIR (newDir) FILE (newFilename) has event Added`
- `DIR (newDir) FILE (newFilename) has event Modified`

_New behavior:_
- `DIR (newDir) FILE (newFilename) has event Moved from (oldDir + oldFilename)`

This new behavior would only work on Linux with inotify, and you need to have both directories watched by the same `FileWatcher` instance. Enable the reporting with `LinuxReportCrossDirectoryMoves` as an option.

**Why**
The previous behavior made moved files harder to understand and could lead to noisy or misleading change output. This update makes the reported file changes match the actual intent of the operation more closely.

**What changed**
- Detects file moves within subdirectories as a move event
- Preserves clearer change reporting across directory boundaries
- Adds unit tests covering the new behavior

**Fixes**
Closes #209